### PR TITLE
Revised factorizing implementation and test case data

### DIFF
--- a/src/test/resources/jsonpatch/factorizing-diff.json
+++ b/src/test/resources/jsonpatch/factorizing-diff.json
@@ -130,11 +130,37 @@
         ]
     },
     {
-        "first": { "b": [0, 1, 2, 3], "c": [1]},
+        "first": [0, 1, 2, 3, 4, 5, 6, 7],
+        "second": [3, 6, 4, 5, 7],
+        "patch": [
+            { "op": "remove", "path": "/0" },
+            { "op": "remove", "path": "/0" },
+            { "op": "remove", "path": "/0" },
+            { "op": "move", "from": "/3", "path": "/1" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3], "c": [1] },
         "second": { "b": [1, 3], "c": [0, 1] },
         "patch": [
             { "op": "remove", "path": "/b/2" },
             { "op": "move", "from": "/b/0", "path": "/c/0" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3], "c": [1], "d": [] },
+        "second": { "b": [1, 3], "c": [2, 1], "d": [0] },
+        "patch": [
+            { "op": "move", "from": "/b/2", "path": "/c/0" },
+            { "op": "move", "from": "/b/0", "path": "/d/-" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3], "c": [1], "d": [] },
+        "second": { "b": [1, 3], "c": [0, 1], "d": [2] },
+        "patch": [
+            { "op": "move", "from": "/b/0", "path": "/c/0" },
+            { "op": "move", "from": "/b/1", "path": "/d/-" }
         ]
     },
     {
@@ -158,6 +184,51 @@
             { "op": "move", "from": "/b/0", "path": "/c" },
             { "op": "add", "path": "/b/1", "value": 2 },
             { "op": "remove", "path": "/b/3" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 3, 4, 5] },
+        "second": { "b": [1, 2, 3, 5], "c": 0, "d": 4 },
+        "patch": [
+            { "op": "move", "from": "/b/0", "path": "/c" },
+            { "op": "move", "from": "/b/2", "path": "/d" },
+            { "op": "add", "path": "/b/1", "value": 2 }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 3, 4, 5] },
+        "second": { "b": [1, 2, 3, 5], "c": 4, "d": 0 },
+        "patch": [
+            { "op": "move", "from": "/b/3", "path": "/c" },
+            { "op": "move", "from": "/b/0", "path": "/d" },
+            { "op": "add", "path": "/b/1", "value": 2 }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        "second": { "b": [1, 6, 2, 3, 5, 7, 0, 8], "c": 4 },
+        "patch": [
+            { "op": "move", "from": "/b/4", "path": "/c" },
+            { "op": "move", "from": "/b/5", "path": "/b/2" },
+            { "op": "move", "from": "/b/0", "path": "/b/6" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        "second": { "b": [1, 3, 6, 4, 5, 7, 8], "c": 2 },
+        "patch": [
+            { "op": "move", "from": "/b/2", "path": "/c" },
+            { "op": "remove", "path": "/b/0" },
+            { "op": "move", "from": "/b/4", "path": "/b/2" }
+        ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        "second": { "b": [1, 3, 6, 4, 5, 7, 0, 8], "c": 2 },
+        "patch": [
+            { "op": "move", "from": "/b/2", "path": "/c" },
+            { "op": "move", "from": "/b/5", "path": "/b/3" },
+            { "op": "move", "from": "/b/0", "path": "/b/6" }
         ]
     }
 ]


### PR DESCRIPTION
Revise factorizing implementation and test cases to cover multiple overlapping add/remove diff array index adjustments. The implementation now properly tracks multiple deferred and advanced removes so that array indexes can be computed properly as the factorizing pass is made on the diffs. To do this, add and remove diffs are paired up front and the pairings are recorded by new members in the diffs themselves for the subsequent factorizing pass. I am guessing that this moves the approach closer to what you had imagined up front.

Also, I cosmetically enhanced the object diffs by preserving field order for the adds, removes, and commons sets. This predictability makes the tests easier to compose and follow. I suppose that will also apply to anyone looking at the generated diffs.

Finally, the refactoring of the LCS algorithm introduced a significant bug that messed up the order of the result when common beginning elements were supposed to be prepended and instead were appended, (that was a bugger to track down)!
