### PR TITLE
Add factorizing support for converting duplicate add to copy operations

### DIFF
--- a/src/test/resources/jsonpatch/factorizing-diff.json
+++ b/src/test/resources/jsonpatch/factorizing-diff.json
@@ -230,5 +230,58 @@
             { "op": "move", "from": "/b/5", "path": "/b/3" },
             { "op": "move", "from": "/b/0", "path": "/b/6" }
         ]
+    },
+    {
+        "first": { "b": [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+        "second": { "b": [1, 3, 6, 4, 5, 7, 0, 8], "c": 2 },
+        "patch": [
+            { "op": "move", "from": "/b/2", "path": "/c" },
+            { "op": "move", "from": "/b/5", "path": "/b/3" },
+            { "op": "move", "from": "/b/0", "path": "/b/6" }
+        ]
+    },
+    {
+        "first": {},
+        "second": { "a": 1, "b": 1},
+        "patch": [
+            { "op": "add", "path": "/a", "value": 1 },
+            { "op": "add", "path": "/b", "value": 1 }
+        ]
+    },
+    {
+        "first": {},
+        "second": { "a": {}, "b": {}},
+        "patch": [
+            { "op": "add", "path": "/a", "value": {} },
+            { "op": "add", "path": "/b", "value": {} }
+        ]
+    },
+    {
+        "first": {},
+        "second": { "a": { "a": 1 }, "b": { "a": 1.0 }},
+        "patch": [
+            { "op": "add", "path": "/a", "value": { "a": 1 } },
+            { "op": "copy", "from": "/a", "path": "/b" }
+        ]
+    },
+    {
+        "first": [],
+        "second": [ [ 0 ], [ 0 ] ],
+        "patch": [
+            { "op": "add", "path": "/-", "value": [ 0 ] },
+            { "op": "add", "path": "/-", "value": [ 0 ] }
+        ]
+    },
+    {
+        "first": [ "eol" ],
+        "second": [ { "a": 1 }, { "a": 1.0 }, [], [], [ 0 ], [ 0 ], "eol" ],
+        "patch": [
+            { "op": "add", "path": "/0", "value": { "a": 1 } },
+            { "op": "copy", "from": "/0", "path": "/1" },
+            { "op": "add", "path": "/2", "value": [] },
+            { "op": "add", "path": "/3", "value": [] },
+            { "op": "add", "path": "/4", "value": [ 0 ] },
+            { "op": "copy", "from": "/4", "path": "/5" }
+        ]
     }
 ]


### PR DESCRIPTION
Added simple logic to and convert subsequent duplicate value'd add operations to copy operations along with test cases. Only non-empty array and object add values are considered since using copy operations for single or simple values would not the reduce patch operation count and would obfuscate patches that otherwise might be trivial.

There is only one wrinkle with this implementation: adds that are appending values to the end of a list cannot be used for subsequent copies. This is because the value does not have a concrete path from which to copy, (the from path cannot be computed easily based on the diff data currently available). This case should be generally rare and probably is not worth writing special case code or abandoning the append path in general to make work. The new test cases include an example of this limitation.
