### PR TITLE
Ensure JsonNodes are ContainerNodes in AddOperation

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/AddOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/AddOperation.java
@@ -91,9 +91,13 @@ public final class AddOperation
         if (parentNode.isMissingNode())
             throw new JsonPatchException(BUNDLE.getMessage(
                 "jsonPatch.noSuchParent"));
-        return parentNode.isArray()
-            ? addToArray(path, node)
-            : addToObject(path, node);
+        if (parentNode.isArray())
+            return addToArray(path, node);
+        else if (parentNode.isObject())
+            return addToObject(path, node);
+        else
+            throw new JsonPatchException(BUNDLE.getMessage(
+                    "jsonPatch.noSuchPath"));
     }
 
     private JsonNode addToArray(final JsonPointer path, final JsonNode node)

--- a/src/test/java/com/github/fge/jsonpatch/AddOperationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/AddOperationTest.java
@@ -18,6 +18,13 @@
 
 package com.github.fge.jsonpatch;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.github.fge.jackson.JacksonUtils;
+import com.github.fge.jackson.jsonpointer.JsonPointer;
+import com.github.fge.jackson.jsonpointer.JsonPointerException;
+import org.testng.annotations.Test;
+
 import java.io.IOException;
 
 public final class AddOperationTest
@@ -27,5 +34,17 @@ public final class AddOperationTest
         throws IOException
     {
         super("add");
+    }
+
+    @Test(expectedExceptions = JsonPatchException.class, expectedExceptionsMessageRegExp = "no such path in target JSON document")
+    public void addingToANonContainerNodeThrowsException()
+            throws JsonPatchException, JsonPointerException
+    {
+        final ObjectNode node = JacksonUtils.nodeFactory().objectNode();
+        final TextNode textNode = JacksonUtils.nodeFactory().textNode("bar");
+        node.put("foo", textNode);
+        final JsonPointer p = new JsonPointer("/foo/f");
+        final JsonPatchOperation op = new AddOperation(p, JacksonUtils.nodeFactory().nullNode());
+        op.apply(node);
     }
 }


### PR DESCRIPTION
Fixes a `ClassCastException` when `AddOperation` attempts to add to a non-`ContainerNode`. For example patching:

```
{
  "foo": "bar"
}
```

with the patch:

```
[ { "op": "add", "path": "/foo/f", "value": "bar" } ]
```

With this patch, `AddOperation` will throw a `JsonPatchException` in this case.

Thank you for dual licensing under ASL 2.0. :smile:
