### PR TITLE
Fix issue that causes some unit tests not to get executed when run from command line

### DIFF
--- a/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static org.testng.Assert.*;
 
+@Test
 public abstract class JsonPatchOperationTest
 {
     private static final MessageBundle BUNDLE


### PR DESCRIPTION
Currently there are a lot of unit tests that don't get executed because they do not contain any classes of their own.  You can see this by looking in the build report directory.  The easiest way to remedy this situation is to just add an @Test annotation to the parent class, that will make sure all these tests get executed.
