### PR TITLE
Issue #11 patch on refactored branch/code line

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/diff/Diff.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/Diff.java
@@ -51,14 +51,12 @@ final class Diff
      * "Stateless" removal of a given node from an array given a base path (the
      * immediate parent of an array) and an array index; as the name suggests,
      * this factory method is called only when a node is removed from the tail
-     * of a target array; in other words, the source node has extra elements,
-     * and the only relevant information for generating the removal operation is
-     * the index in the source array.
+     * of a target array; in other words, the source node has extra elements.
      */
     static Diff tailArrayRemove(final JsonPointer basePath, final int index,
-        final JsonNode victim)
+        final int removeIndex, final JsonNode victim)
     {
-        return new Diff(DiffOperation.REMOVE, basePath, index, index,
+        return new Diff(DiffOperation.REMOVE, basePath, index, removeIndex,
             victim.deepCopy());
     }
 

--- a/src/main/java/com/github/fge/jsonpatch/diff/IndexedJsonArray.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/IndexedJsonArray.java
@@ -68,4 +68,9 @@ final class IndexedJsonArray
     {
         return index >= size;
     }
+
+    int size()
+    {
+        return size;
+    }
 }

--- a/src/main/java/com/github/fge/jsonpatch/diff/JsonDiff.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/JsonDiff.java
@@ -397,7 +397,7 @@ public final class JsonDiff
             target.shift();
         }
         addRemaining(diffs, path, target);
-        removeRemaining(diffs, path, source);
+        removeRemaining(diffs, path, source, target.size());
     }
 
     private static void addRemaining(final List<Diff> diffs,
@@ -415,16 +415,16 @@ public final class JsonDiff
     }
 
     private static void removeRemaining(final List<Diff> diffs,
-        final JsonPointer path, final IndexedJsonArray array)
+        final JsonPointer path, final IndexedJsonArray array,
+        final int removeIndex)
     {
-        final int startingIndex = array.getIndex();
-
         Diff diff;
         JsonNode node;
 
         while (!array.isEmpty()) {
             node = array.getElement();
-            diff = Diff.tailArrayRemove(path, startingIndex, node);
+            diff = Diff.tailArrayRemove(path, array.getIndex(),
+                                        removeIndex, node);
             diffs.add(diff);
             array.shift();
         }


### PR DESCRIPTION
Correct 'removeRemaining()' Diff creation from postLCS(): set secondArrayIndex used by array diffs to remove index, (which is the second array length in this case).

The comment in the original Diff.tailArrayRemove() code was incorrect: the Diff.secondArrayIndex is used to generate array difference/patch objects. This patch ensures that is set correctly. Because these are removes at the tail, we know that the secondArrayIndex will be equal to the length of the second array... .as if we were removing all elements that were in that position when the patch would be applied to ensure that the second array ends up at that length when done. 
