### PR TITLE
bug fix in move operation

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/diff/DiffFactorizer.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/DiffFactorizer.java
@@ -25,6 +25,8 @@ import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.Lists;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -106,6 +108,7 @@ final class DiffFactorizer
     private static void findPairs(final List<Diff> diffs)
     {
         final int diffsSize = diffs.size();
+        Collection<Diff> alreadyPaired = new HashSet<Diff>();
 
         Diff addition, removal;
 
@@ -119,7 +122,7 @@ final class DiffFactorizer
              */
             for (int removeIndex = 0; removeIndex < diffsSize; removeIndex++) {
                 removal = diffs.get(removeIndex);
-                if (removal.operation != DiffOperation.REMOVE)
+                if (removal.operation != DiffOperation.REMOVE || alreadyPaired.contains(removal))
                     continue;
                 if (!EQUIVALENCE.equivalent(removal.value, addition.value))
                     continue;
@@ -131,6 +134,10 @@ final class DiffFactorizer
                 addition.firstOfPair = addIndex < removeIndex;
                 removal.pairedDiff = addition;
                 removal.firstOfPair = removeIndex < addIndex;
+
+                alreadyPaired.add(removal);
+                alreadyPaired.add(addition);
+
                 break;
             }
         }

--- a/src/test/resources/jsonpatch/factorizing-diff.json
+++ b/src/test/resources/jsonpatch/factorizing-diff.json
@@ -296,5 +296,13 @@
             { "op": "remove", "path": "/0" },
             { "op": "remove", "path": "/1" }
         ]
+    },
+    {
+        "first": { "b": [0, 1, 2] },
+        "second": { "b": [1, 2], "c": 0 ,"d":0},
+        "patch": [
+        { "op": "move", "from": "/b/0", "path": "/c"},
+        { "op": "add", "path": "/d", "value": 0}
+        ]
     }
 ]


### PR DESCRIPTION
There was bug in factorization of  diffs while finding pairs. 
Example : 
 "first": { "b": [0, 1, 2] },
 "second": { "b": [1, 2], "c": 0 ,"d":0}
patch obtained is : 
{{ "op": "move", "from": "/b/0", "path": "/c"}, { "op": "move", "from": "/b/0", "path": "/d"}} 
which is wrong, the correct patch generated should be
 { "op": "move", "from": "/b/0", "path": "/c"},{ "op": "add", "path": "/d", "value": 0} 
There was bug in finding pair method, I have added necessary code fix for same.
