### PR TITLE
Enforce OSGI Import-Package of guava libraries to use version >=16 && < 19, to allow using with latest Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,15 @@ task pom << {
     pom {}.writeTo("${projectDir}/pom.xml");
 }
 
+jar {
+    manifest {
+        instruction 'Import-Package', 'com.google.common.base;version="[16.0,19)",'+
+            'com.google.common.collect;version="[16.0,19)",'+
+            'com.google.common.io;version="[16.0,19)",'+
+             '*';
+    }
+}
+
 /*
  * SIGNING
  */


### PR DESCRIPTION
Please see https://github.com/fge/jackson-coreutils/pull/5, same & related issue.
