### PR TITLE
Add getter for the patch operations

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
@@ -31,6 +31,7 @@ import com.github.fge.msgsimple.load.MessageBundles;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -148,6 +149,15 @@ public final class JsonPatch
 
         return ret;
     }
+    
+    /**
+     * Return the operations that are part of this patch
+     * 
+     * @return the operations of the patch
+     */
+    public List<JsonPatchOperation> getOperations() {
+		return new ArrayList<JsonPatchOperation>(operations);
+	}
 
     @Override
     public String toString()


### PR DESCRIPTION
It might be necessary in projects where an all or nothing approach
to patching is not helpful and a more fine-grain approach is needed.

This was necessary in a project where I had to use this tool and the users were interested in applying as many operations as possible and reporting the ones that couldn't be applied.