### PR TITLE
Added getters for JsonPatch and Operations

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/DualPathOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/DualPathOperation.java
@@ -72,6 +72,10 @@ public abstract class DualPathOperation
         serialize(jgen, provider);
     }
 
+    public JsonPointer getFrom() {
+        return from;
+    }
+
     @Override
     public final String toString()
     {

--- a/src/main/java/com/github/fge/jsonpatch/DualPathOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/DualPathOperation.java
@@ -72,7 +72,7 @@ public abstract class DualPathOperation
         serialize(jgen, provider);
     }
 
-    public JsonPointer getFrom() {
+    public final JsonPointer getFrom() {
         return from;
     }
 

--- a/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
@@ -151,6 +151,10 @@ public final class JsonPatch
         return ret;
     }
 
+    public List<JsonPatchOperation> getOperations() {
+        return operations;
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatch.java
@@ -151,7 +151,7 @@ public final class JsonPatch
         return ret;
     }
 
-    public List<JsonPatchOperation> getOperations() {
+    public final List<JsonPatchOperation> getOperations() {
         return operations;
     }
 

--- a/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
@@ -94,6 +94,14 @@ public abstract class JsonPatchOperation
     public abstract JsonNode apply(final JsonNode node)
         throws JsonPatchException;
 
+    public String getOp() {
+        return op;
+    }
+
+    public JsonPointer getPath() {
+        return path;
+    }
+
     @Override
     public abstract String toString();
 }

--- a/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
@@ -94,11 +94,11 @@ public abstract class JsonPatchOperation
     public abstract JsonNode apply(final JsonNode node)
         throws JsonPatchException;
 
-    public String getOp() {
+    public final String getOp() {
         return op;
     }
 
-    public JsonPointer getPath() {
+    public final JsonPointer getPath() {
         return path;
     }
 

--- a/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
@@ -73,8 +73,8 @@ public abstract class PathValueOperation
         serialize(jgen, provider);
     }
 
-    public JsonNode getValue() {
-        return value;
+    public final JsonNode getValue() {
+        return value.deepCopy();
     }
 
     @Override

--- a/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
@@ -73,6 +73,10 @@ public abstract class PathValueOperation
         serialize(jgen, provider);
     }
 
+    public JsonNode getValue() {
+        return value;
+    }
+
     @Override
     public final String toString()
     {


### PR DESCRIPTION
Hoping this gets picked up & released due to recent activity by @Capstan :)

- Added JsonPatch.getOperations()
- Added field getters for operations
  - DualPathOperation.getFrom()
  - JsonPatchOperation.getOp() and JsonPatchOperation.getPath()
  - PathValueOperation.getValue()

Personal use case is needing to determine which class to patch when using subtypes, and the type info being held in a field which may be modified by a replace operation.

Solves #33 
Supercedes #45 