### PR TITLE
bugfix when handling array

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/diff/DiffProcessor.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/DiffProcessor.java
@@ -59,9 +59,7 @@ final class DiffProcessor
         final int removalIndex = findPreviouslyRemoved(value);
         if (removalIndex != -1) {
             final DiffOperation removed = diffs.get(removalIndex);
-            diffs.remove(removalIndex);
-            diffs.add(DiffOperation.move(removed.getFrom(),
-                value, pointer, value));
+            diffs.set(removalIndex, DiffOperation.move(removed.getFrom(), value, pointer, value));
             return;
         }
         final JsonPointer ptr = findUnchangedValue(value);


### PR DESCRIPTION
there is a bug that all the operations in `diffs` are stateful in the sense that their operation depends on the operations before them. 

The remove and add case breaks the diffs order b/c it removes and add to the end of `diffs`. 

repro: 

```
    @Test
    void testJsonPatchBug() throws JsonProcessingException, JsonPatchException {
        JsonNode config1 = YAML_MAPPER.readTree(""
                + "foo:\n"
                + "  - bar:\n"
                + "      - baz: a\n"
                + "      - baz: b\n"
                + "      - baz: c\n"
                + "  - bar:\n"
                + "      - baz: d\n");
        JsonNode config2 = YAML_MAPPER.readTree(""
                + "foo:\n"
                + "- bar:\n"
                + "  - baz: d\n"
                + "- bar:\n"
                + "  - baz: c\n"
                + "  - baz: b\n"
                + "  - baz: a\n");
        Assertions.assertThat(JsonDiff.asJsonPatch(config1, config2).apply(config1))
                .isEqualTo(config2);

    }

# test fails the actual config is : 
foo:
- bar:
  - baz: d
- bar:
  - baz: c
  - baz: c
  - baz: a

```