### PR TITLE
Informative msgs when JsonPatchException is thrown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url "http://repo.springsource.org/plugins-release";
+            url "https://repo.springsource.org/plugins-release";
         }
     }
     dependencies {
@@ -31,7 +31,7 @@ buildscript {
 };
 
 plugins {
-    id("net.ltgt.errorprone") version "0.8.1" apply false
+    id("net.ltgt.errorprone") version "1.3.0" apply false
 }
 
 configure(allprojects) {

--- a/src/main/java/com/github/fge/jsonpatch/AddOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/AddOperation.java
@@ -91,11 +91,20 @@ public final class AddOperation
          */
         final JsonNode parentNode = path.parent().path(node);
         if (parentNode.isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.noSuchParent"));
-        if (!parentNode.isContainerNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.parentNotContainer"));
+        {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchParent");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
+        if (!parentNode.isContainerNode()) {
+            String msg = BUNDLE.getMessage("jsonPatch.parentNotContainer");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         return parentNode.isArray()
             ? addToArray(path, node)
             : addToObject(path, node);
@@ -119,12 +128,12 @@ public final class AddOperation
         try {
             index = Integer.parseInt(token.toString());
         } catch (NumberFormatException ignored) {
-            throw new JsonPatchException(BUNDLE.getMessage(
+            throw new JsonPatchException("[] " + BUNDLE.getMessage(
                 "jsonPatch.notAnIndex"));
         }
 
         if (index < 0 || index > size)
-            throw new JsonPatchException(BUNDLE.getMessage(
+            throw new JsonPatchException(node.toString() + " " + BUNDLE.getMessage(
                 "jsonPatch.noSuchIndex"));
 
         target.insert(index, value);

--- a/src/main/java/com/github/fge/jsonpatch/CopyOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/CopyOperation.java
@@ -55,9 +55,13 @@ public final class CopyOperation
         throws JsonPatchException
     {
         final JsonNode dupData = from.path(node).deepCopy();
-        if (dupData.isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.noSuchPath"));
+        if (path.path(dupData).isMissingNode()) {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
+            if(dupData!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         return new AddOperation(path, dupData).apply(node);
     }
 }

--- a/src/main/java/com/github/fge/jsonpatch/CopyOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/CopyOperation.java
@@ -55,7 +55,7 @@ public final class CopyOperation
         throws JsonPatchException
     {
         final JsonNode dupData = from.path(node).deepCopy();
-        if (path.path(dupData).isMissingNode()) {
+        if(dupData.isMissingNode()){
             String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
             if(dupData!=null) {
                 msg = node.toString() + " " + msg;

--- a/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
@@ -79,9 +79,13 @@ public final class MoveOperation
         if (from.equals(path))
             return node.deepCopy();
         final JsonNode movedNode = from.path(node);
-        if (movedNode.isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.noSuchPath"));
+        if (movedNode.isMissingNode()) {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         final JsonPatchOperation remove = new RemoveOperation(from);
         final JsonPatchOperation add = new AddOperation(path, movedNode);
         return add.apply(remove.apply(node));

--- a/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
@@ -88,6 +88,24 @@ public final class MoveOperation
         }
         final JsonPatchOperation remove = new RemoveOperation(from);
         final JsonPatchOperation add = new AddOperation(path, movedNode);
-        return add.apply(remove.apply(node));
+        JsonNode returnNode = null;
+        try {
+            returnNode = add.apply(remove.apply(node));
+        }
+        catch(JsonPatchException jpe)
+        {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchParent");
+            if(jpe.getMessage().contains(msg))
+            {
+                // Rethrow the JsonPatchException with a new message
+                msg = node.toString() + " " + msg;
+                throw new JsonPatchException(msg);
+            }
+            else
+            {
+                throw jpe;
+            }
+        }
+        return returnNode;
     }
 }

--- a/src/main/java/com/github/fge/jsonpatch/RemoveOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/RemoveOperation.java
@@ -55,8 +55,13 @@ public final class RemoveOperation
         if (path.isEmpty())
             return MissingNode.getInstance();
         if (path.path(node).isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.noSuchPath"));
+        {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         final JsonNode ret = node.deepCopy();
         final JsonNode parentNode = path.parent().get(ret);
         final String raw = Iterables.getLast(path).getToken().getRaw();

--- a/src/main/java/com/github/fge/jsonpatch/ReplaceOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/ReplaceOperation.java
@@ -62,9 +62,13 @@ public final class ReplaceOperation
          * If remove is done first, the array is empty and add rightly complains
          * that there is no such index in the array.
          */
-        if (path.path(node).isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
-                "jsonPatch.noSuchPath"));
+        if (path.path(node).isMissingNode()) {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         final JsonNode replacement = value.deepCopy();
         if (path.isEmpty())
             return replacement;

--- a/src/main/java/com/github/fge/jsonpatch/TestOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/TestOperation.java
@@ -56,11 +56,15 @@ public final class TestOperation
         throws JsonPatchException
     {
         final JsonNode tested = path.path(node);
-        if (tested.isMissingNode())
-            throw new JsonPatchException(tested.toString() + " "+ BUNDLE.getMessage(
-                "jsonPatch.noSuchPath"));
+        if (tested.isMissingNode()) {
+            String msg = BUNDLE.getMessage("jsonPatch.noSuchPath");
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            throw new JsonPatchException(msg);
+        }
         if (!EQUIVALENCE.equivalent(tested, value))
-            throw new JsonPatchException(tested.toString() + " " + BUNDLE.getMessage(
+            throw new JsonPatchException(node.toString() + " " + BUNDLE.getMessage(
                 "jsonPatch.valueTestFailure"));
         return node.deepCopy();
     }

--- a/src/main/java/com/github/fge/jsonpatch/TestOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/TestOperation.java
@@ -57,10 +57,10 @@ public final class TestOperation
     {
         final JsonNode tested = path.path(node);
         if (tested.isMissingNode())
-            throw new JsonPatchException(BUNDLE.getMessage(
+            throw new JsonPatchException(tested.toString() + " "+ BUNDLE.getMessage(
                 "jsonPatch.noSuchPath"));
         if (!EQUIVALENCE.equivalent(tested, value))
-            throw new JsonPatchException(BUNDLE.getMessage(
+            throw new JsonPatchException(tested.toString() + " " + BUNDLE.getMessage(
                 "jsonPatch.valueTestFailure"));
         return node.deepCopy();
     }

--- a/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
@@ -81,12 +81,6 @@ public abstract class JsonPatchOperationTest
         throws IOException
     {
         final JsonPatchOperation op = reader.readValue(patch);
-        System.out.println("Message is:"+ message);
-        if(message.equals("parent of node to add does not exist"))
-        {
-            System.out.println("Stop here");
-        }
-
         try {
             op.apply(node);
             fail("No exception thrown!!");
@@ -94,12 +88,6 @@ public abstract class JsonPatchOperationTest
             String msg = message;
             if(node!=null) {
                 msg = node.toString() + " " + msg;
-            }
-            String className = this.getClass().toString();
-            System.out.println("ClassName is:"+ className);
-            if(!msg.equalsIgnoreCase(e.getMessage()) && className.contains("CopyOperationTest"))
-            {
-                System.out.println("Stop here");
             }
             assertEquals(e.getMessage(), msg);
         }
@@ -125,11 +113,6 @@ public abstract class JsonPatchOperationTest
         final JsonNode node, final JsonNode expected)
         throws IOException, JsonPatchException
     {
-        String className = this.getClass().toString();
-        if(className.contains("CopyOperationTest"))
-        {
-            System.out.println("");
-        }
         final JsonPatchOperation op = reader.readValue(patch);
         final JsonNode actual = op.apply(node);
 

--- a/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/JsonPatchOperationTest.java
@@ -81,12 +81,27 @@ public abstract class JsonPatchOperationTest
         throws IOException
     {
         final JsonPatchOperation op = reader.readValue(patch);
+        System.out.println("Message is:"+ message);
+        if(message.equals("parent of node to add does not exist"))
+        {
+            System.out.println("Stop here");
+        }
 
         try {
             op.apply(node);
             fail("No exception thrown!!");
         } catch (JsonPatchException e) {
-            assertEquals(e.getMessage(), message);
+            String msg = message;
+            if(node!=null) {
+                msg = node.toString() + " " + msg;
+            }
+            String className = this.getClass().toString();
+            System.out.println("ClassName is:"+ className);
+            if(!msg.equalsIgnoreCase(e.getMessage()) && className.contains("CopyOperationTest"))
+            {
+                System.out.println("Stop here");
+            }
+            assertEquals(e.getMessage(), msg);
         }
     }
 
@@ -110,6 +125,11 @@ public abstract class JsonPatchOperationTest
         final JsonNode node, final JsonNode expected)
         throws IOException, JsonPatchException
     {
+        String className = this.getClass().toString();
+        if(className.contains("CopyOperationTest"))
+        {
+            System.out.println("");
+        }
         final JsonPatchOperation op = reader.readValue(patch);
         final JsonNode actual = op.apply(node);
 


### PR DESCRIPTION
1) This PR adds informative msgs to the cases when JsonPatchException is thrown . (for example a missing path is passed etc.). 
2) All the tests have been modified to take in to account the new messages. 
3) We have used this software in our internal project and found it useful to have this information when some thing changed on our backend and the front end was in sync. It would throw generic jsonPatchException (with noSuchPath or noSuchParent which while useful would not pin point to the location of the error. This becomes a problem in projects with quite a few team members who  are not proficient in debugging and the architecture is complex. 
4) All the tests are passing after the changes. 