### PR TITLE
Enables adding/removing arrays to/from arrays

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/AddOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/AddOperation.java
@@ -136,7 +136,23 @@ public final class AddOperation
         final TokenResolver<JsonNode> token = Iterables.getLast(path);
         final JsonNode ret = node.deepCopy();
         final ObjectNode target = (ObjectNode) path.parent().get(ret);
-        target.set(token.getToken().getRaw(), value);
+
+        final String objectName = token.getToken().getRaw();
+        final JsonNode targetObject = target.get(objectName);
+
+        if (targetObject != null && targetObject.isArray()) {
+            addToArrayObject((ArrayNode) targetObject);
+        } else {
+            target.set(objectName, value);
+        }
         return ret;
+    }
+
+    private void addToArrayObject(ArrayNode targetObject) {
+        if (value.isArray()) {
+            targetObject.addAll((ArrayNode) value);
+        } else {
+            targetObject.add(value);
+        }
     }
 }

--- a/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/MoveOperation.java
@@ -22,6 +22,7 @@ package com.github.fge.jsonpatch;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 
 /**
@@ -82,7 +83,7 @@ public final class MoveOperation
         if (movedNode.isMissingNode())
             throw new JsonPatchException(BUNDLE.getMessage(
                 "jsonPatch.noSuchPath"));
-        final JsonPatchOperation remove = new RemoveOperation(from);
+        final JsonPatchOperation remove = new RemoveOperation(from, NullNode.getInstance());
         final JsonPatchOperation add = new AddOperation(path, movedNode);
         return add.apply(remove.apply(node));
     }

--- a/src/main/java/com/github/fge/jsonpatch/diff/DiffOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/DiffOperation.java
@@ -20,6 +20,7 @@
 package com.github.fge.jsonpatch.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonpatch.AddOperation;
 import com.github.fge.jsonpatch.CopyOperation;
@@ -145,7 +146,7 @@ final class DiffOperation
             @Override
             JsonPatchOperation toOperation(final DiffOperation op)
             {
-                return new RemoveOperation(op.from);
+                return new RemoveOperation(op.from, NullNode.getInstance());
             }
         },
         REPLACE

--- a/src/test/java/com/github/fge/jsonpatch/RemoveOperationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/RemoveOperationTest.java
@@ -20,6 +20,7 @@
 package com.github.fge.jsonpatch;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.github.fge.jackson.JacksonUtils;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import org.testng.annotations.Test;
@@ -42,7 +43,7 @@ public final class RemoveOperationTest
         throws JsonPatchException
     {
         final JsonNode node = JacksonUtils.nodeFactory().nullNode();
-        final JsonPatchOperation op = new RemoveOperation(JsonPointer.empty());
+        final JsonPatchOperation op = new RemoveOperation(JsonPointer.empty(), NullNode.getInstance());
         final JsonNode ret = op.apply(node);
         assertTrue(ret.isMissingNode());
     }

--- a/src/test/resources/jsonpatch/add.json
+++ b/src/test/resources/jsonpatch/add.json
@@ -53,6 +53,16 @@
             "expected": { "array": [ 2, null, "hello", {}, 1 ] }
         },
         {
+            "op": { "op": "add", "path": "/array", "value": ["world"] },
+            "node": { "array": ["hello"] },
+            "expected": { "array": [ "hello", "world" ] }
+        },
+        {
+            "op": { "op": "add", "path": "/array", "value": ["hello"] },
+            "node": {},
+            "expected": { "array": [ "hello" ] }
+        },
+        {
             "op": { "op": "add", "path": "/obj/inner/b", "value": [ 1, 2 ] },
             "node": {
                 "obj": {

--- a/src/test/resources/jsonpatch/remove.json
+++ b/src/test/resources/jsonpatch/remove.json
@@ -8,6 +8,21 @@
     ],
     "ops": [
         {
+            "op": { "op": "remove", "path": "/x", "value": "y" },
+            "node": { "x": [ "y", "z" ], "foo": "bar" },
+            "expected": { "x": [ "z" ], "foo": "bar" }
+        },
+        {
+            "op": { "op": "remove", "path": "/x", "value": ["z"] },
+            "node": { "x": [ "y", "z" ], "foo": "bar" },
+            "expected": { "x": [ "y" ], "foo": "bar" }
+        },
+        {
+            "op": { "op": "remove", "path": "/x", "value": {"a":  3} },
+            "node": { "x": [ {"a":  3}, "z" ], "foo": "bar" },
+            "expected": { "x": [ "z" ], "foo": "bar" }
+        },
+        {
             "op": { "op": "remove", "path": "/x/y" },
             "node": { "x": { "a": "b", "y": {} } },
             "expected": { "x": { "a": "b" } }


### PR DESCRIPTION
Example request bodies:

```JSON
{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "Add",
        "path": "members",
        "value": [{
            "$ref": null,
            "value": "f648f8d5ea4e4cd38e9c"
        }]
    }]
}
```
```JSON
{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "Remove",
        "path": "members",
        "value": [{
            "$ref": null,
            "value": "f648f8d5ea4e4cd38e9c"
        }]
    }]
}
```

Although I'm not quite sure if this is strictly part of the protocol, I encountered the problem while implementing a SCIM2 service where this seems to be common practice:

https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#request-11

https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#request-12

https://docs.snowflake.com/en/user-guide/scim-intro.html#patch-scim-v2-groups-id