### PR TITLE
Add validation to the input patch during parsing

### DIFF
--- a/src/main/resources/com/github/fge/jsonpatch/messages.properties
+++ b/src/main/resources/com/github/fge/jsonpatch/messages.properties
@@ -20,6 +20,7 @@
 common.nullArgument=argument cannot be null
 jsonPatch.deserFailed=unable to deserialize JSON input
 jsonPatch.nullInput=input cannot be null
+jsonPatch.invalidPatch=invalid Json patch {0}
 jsonPatch.nullValue=value cannot be null
 jsonPatch.noSuchParent=parent of node to add does not exist
 jsonPatch.notAnIndex=reference token is not an array index

--- a/src/test/java/com/github/fge/jsonpatch/ValidationTest.java
+++ b/src/test/java/com/github/fge/jsonpatch/ValidationTest.java
@@ -1,0 +1,58 @@
+package com.github.fge.jsonpatch;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import static com.github.fge.jsonpatch.JsonPatchOperation.BUNDLE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class ValidationTest {
+    // the test cases have comments in them to explain the specific test case
+    // hence use a custom Object mapper that allows Json comments
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+                                                   .enable(JsonParser.Feature.ALLOW_COMMENTS);
+
+    @DataProvider
+    public final Iterator<Object[]> getInvalidJsonPatches() throws IOException
+    {
+        final JsonNode patches = MAPPER.readTree(
+            new InputStreamReader(
+                Objects.requireNonNull(ValidationTest.class.getResourceAsStream(
+                    "/jsonpatch/invalid-patches.json"
+                )),
+                StandardCharsets.UTF_8
+            )
+        );
+
+        final List<Object[]> list = Lists.newArrayList();
+
+        for (final JsonNode patch: patches) {
+            list.add(new Object[] {patch});
+        }
+
+        return list.iterator();
+    }
+
+    @Test(dataProvider = "getInvalidJsonPatches")
+    public final void invalidPatchesAreDetected(final JsonNode patch) throws IOException
+    {
+        try {
+            JsonPatch.fromJson(patch);
+            fail("No exception thrown!!");
+        } catch (IllegalArgumentException ie) {
+            assertEquals(ie.getMessage(), BUNDLE.format("jsonPatch.invalidPatch", patch));
+        }
+    }
+}

--- a/src/test/resources/jsonpatch/invalid-patches.json
+++ b/src/test/resources/jsonpatch/invalid-patches.json
@@ -1,0 +1,40 @@
+[
+  // predicate with no operation
+  [{"path": "/field1", "value": {"id":123}}],
+
+  // predicate with no path
+  [{"op": "test", "value": {"id":123}}],
+
+  // predicate with no value
+  [{"op": "test", "path": "/field1"}],
+
+  // predicate with non-text path attribute
+  [{"op": "test", "path": 1, "value": {"id":123}}],
+
+  // patch with no operation
+  [{"path": "/field1/a", "value": "b"}],
+
+  // patch with no path
+  [{"op": "add", "value": "b"}],
+
+  // patch with non-text path
+  [{"op": "add", "path": 123, "value": "b"}],
+
+  // ADD patch with no value
+  [{"op": "add", "path": "/field1/a"}],
+
+  // REPLACE patch with no value
+  [{"op": "replace", "path": "/field1/a"}],
+
+  // MOVE patch with no from attribute
+  [{"op": "move", "path": "/field1/a"}],
+
+  // COPY patch with no from attribute
+  [{"op": "move", "path": "/field1/a"}],
+
+  // MOVE patch with no non-text from attribute
+  [{"op": "move", "path": "/field1/a", "from": 123}],
+
+  // COPY patch with no non-text from attribute
+  [{"op": "copy", "path": "/field1/a", "from": 123}]
+]


### PR DESCRIPTION
Adding validation to the input when parsing a Json patch. If the validation fails, the code throws an IllegalArgumentException. Also added tests to validate the different cases are handled.